### PR TITLE
Fix library path for multilib

### DIFF
--- a/dmd/PKGBUILD
+++ b/dmd/PKGBUILD
@@ -16,10 +16,12 @@ url="http://www.dlang.org"
 makedepends=('git' 'gcc' 'make' 'dmd' 'libphobos-devel')
 source=("git+http://github.com/D-Programming-Language/dmd.git#tag=v$pkgver"
         "git+http://github.com/D-Programming-Language/druntime.git#tag=v$pkgver"
-        "git+http://github.com/D-Programming-Language/phobos.git#tag=v$pkgver")
+        "git+http://github.com/D-Programming-Language/phobos.git#tag=v$pkgver"
+        "dmd.conf")
 sha1sums=('SKIP'
           'SKIP'
-          'SKIP')
+          'SKIP'
+          '6151874cd03fe2d0e017b5630a1789b86aea6cc5')
 
 [[ $CARCH == "x86_64" ]] && _archbits="64"
 [[ $CARCH == "i686" ]] && _archbits="32"
@@ -52,7 +54,7 @@ package_dmd() {
     install -Dm755 $srcdir/dmd/src/dmd $pkgdir/usr/bin/dmd
 
     mkdir -p $pkgdir/etc
-    echo -e "[Environment]\nDFLAGS=-I/usr/include/dlang/dmd -L-L/usr/lib -L-L/usr/lib32 -L--export-dynamic" > $pkgdir/etc/dmd.conf
+    install -Dm644 $srcdir/dmd.conf $pkgdir/etc/dmd.conf
 
     mkdir -p $pkgdir/usr/share/man/man1
     mkdir -p $pkgdir/usr/share/man/man5

--- a/dmd/dmd.conf
+++ b/dmd/dmd.conf
@@ -1,0 +1,5 @@
+[Environment32]
+DFLAGS=-I/usr/include/dlang/dmd -L-L/usr/lib32 -L--export-dynamic
+
+[Environment64]
+DFLAGS=-I/usr/include/dlang/dmd -L-L/usr/lib -L--export-dynamic


### PR DESCRIPTION
Hi.

In 2.071.1-1, Arch's dmd failed to build with -m32 option.
It should to define paths on each bit-widths in /etc/dmd.conf like upstream dmd.

```
$ LANG=C dmd source.d -m32
/usr/bin/ld: skipping incompatible /usr/lib/libphobos2.a when searching for -lphobos2
/usr/bin/ld: skipping incompatible /usr/lib/libpthread.so when searching for -lpthread
/usr/bin/ld: skipping incompatible /usr/lib/libpthread.a when searching for -lpthread
/usr/bin/ld: skipping incompatible /usr/lib/libm.so when searching for -lm
/usr/bin/ld: skipping incompatible /usr/lib/libm.a when searching for -lm
/usr/bin/ld: skipping incompatible /usr/lib/librt.so when searching for -lrt
/usr/bin/ld: skipping incompatible /usr/lib/librt.a when searching for -lrt
/usr/bin/ld: skipping incompatible /usr/lib/libdl.so when searching for -ldl
/usr/bin/ld: skipping incompatible /usr/lib/libdl.a when searching for -ldl
/usr/bin/ld: skipping incompatible /usr/lib/libgcc_s.so.1 when searching for libgcc_s.so.1
/usr/bin/ld: skipping incompatible /usr/lib/libc.so when searching for -lc
/usr/bin/ld: skipping incompatible /usr/lib/libc.a when searching for -lc
/usr/bin/ld: skipping incompatible /usr/lib/libgcc_s.so.1 when searching for libgcc_s.so.1
```
